### PR TITLE
Fallback to current class loader when the ServiceLocator fails to load a class from context classloader

### DIFF
--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/core/config/spi/LLMConfigProvider.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/core/config/spi/LLMConfigProvider.java
@@ -18,11 +18,15 @@ public class LLMConfigProvider {
         final List<LLMConfig> factories = new ArrayList<>();
         loader.forEach(factories::add);
         if (factories.isEmpty()) {
-            throw new RuntimeException("No service Found for LLMConfig interface");
-        } else {
-            llmConfig = factories.iterator().next(); //loader.findFirst().orElse(null);
-            LOGGER.debug("Found LLMConfig interface: " + llmConfig.getClass().getName());
+            // Use current classloader to load the LLMConfig implementation as a fallback option
+            loader = ServiceLoader.load(LLMConfig.class, LLMConfig.class.getClassLoader());
+            loader.forEach(factories::add);
+            if (factories.isEmpty()) {
+                throw new RuntimeException("No service Found for LLMConfig interface");
+            }
         }
+        llmConfig = factories.iterator().next(); //loader.findFirst().orElse(null);
+        LOGGER.debug("Found LLMConfig interface: " + llmConfig.getClass().getName());
     }
 
     public static LLMConfig getLlmConfig() {

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/plugin/CommonLLMPluginCreator.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/plugin/CommonLLMPluginCreator.java
@@ -208,7 +208,11 @@ public class CommonLLMPluginCreator {
     }
 
     private static Class<?> loadClass(String className) throws ClassNotFoundException {
-        return Thread.currentThread().getContextClassLoader().loadClass(className);
+        try {
+            return Thread.currentThread().getContextClassLoader().loadClass(className);
+        } catch (ClassNotFoundException classNotFoundException) {
+            return CommonLLMPluginCreator.class.getClassLoader().loadClass(className);
+        }
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
This change introduces a fallback mechanism in the class loading logic using ServiceLocator class loading logic in langchain4j-cdi-core module. When an attempt to load a class using the context class loader fails due to any reason, the implementation now falls back to using the current class loader. This ensures that service loading continues gracefully across a wide range of Java runtimes.