### PR TITLE
Upgrading LangChain4J to 1.2.0

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -52,7 +52,7 @@
             <dependency>
                 <groupId>dev.langchain4j</groupId>
                 <artifactId>langchain4j</artifactId>
-                <version>${dev.langchain4j.core.version}</version>
+                <version>${dev.langchain4j.version}</version>
             </dependency>
             <dependency>
                 <groupId>dev.langchain4j</groupId>
@@ -72,7 +72,7 @@
             <dependency>
                 <groupId>dev.langchain4j</groupId>
                 <artifactId>langchain4j-open-ai</artifactId>
-                <version>${dev.langchain4j.core.version}</version>
+                <version>${dev.langchain4j.version}</version>
             </dependency>
             <dependency>
                 <groupId>ai.djl.huggingface</groupId>

--- a/langchain4j-cdi-integration-tests/langchain4j-cdi-integration-tests-helidon/pom.xml
+++ b/langchain4j-cdi-integration-tests/langchain4j-cdi-integration-tests-helidon/pom.xml
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-core</artifactId>
-            <version>${dev.langchain4j.core.version}</version><!-- We MUST force the version because helidon embed a previous version -->
+            <version>${dev.langchain4j.version}</version><!-- We MUST force the version because helidon embed a previous version -->
         </dependency>
         <!-- Logging dependency -->
         <dependency>

--- a/langchain4j-cdi-integration-tests/langchain4j-cdi-integration-tests-jakartaee/pom.xml
+++ b/langchain4j-cdi-integration-tests/langchain4j-cdi-integration-tests-jakartaee/pom.xml
@@ -128,7 +128,7 @@
         <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j-open-ai</artifactId>
-            <version>${dev.langchain4j.core.version}</version>
+            <version>${dev.langchain4j.version}</version>
         </dependency>
         <dependency>
             <groupId>dev.langchain4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -55,9 +55,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <dev.langchain4j.core.version>1.1.0</dev.langchain4j.core.version>
-        <dev.langchain4j.version>1.1.0-rc1</dev.langchain4j.version>
-        <dev.langchain4j.community.version>1.1.0-beta7</dev.langchain4j.community.version>
+        <dev.langchain4j.version>1.2.0</dev.langchain4j.version>
+        <dev.langchain4j.community.version>1.2.0-beta8</dev.langchain4j.community.version>
         <jakartaee-api.version>10.0.0</jakartaee-api.version>
         <jakarta.enterprise.cdi-api.version>4.0.1</jakarta.enterprise.cdi-api.version>
 
@@ -102,7 +101,7 @@
             <dependency>
                 <groupId>dev.langchain4j</groupId>
                 <artifactId>langchain4j-bom</artifactId>
-                <version>${dev.langchain4j.core.version}</version>
+                <version>${dev.langchain4j.version}</version>
                 <type>pom</type>
             </dependency>
             <dependency>
@@ -153,7 +152,7 @@
             <dependency>
                 <groupId>dev.langchain4j</groupId>
                 <artifactId>langchain4j</artifactId>
-                <version>${dev.langchain4j.core.version}</version>
+                <version>${dev.langchain4j.version}</version>
             </dependency>
             <dependency>
                 <groupId>dev.langchain4j.cdi</groupId>


### PR DESCRIPTION
https://github.com/langchain4j/langchain4j/releases/tag/1.2.0