### PR TITLE
Fix bug where LLMConfig did a CDI lookup for all ChatModelListener by ParameterizedType.

### DIFF
--- a/examples/liberty-car-booking/src/main/resources/META-INF/microprofile-config.properties
+++ b/examples/liberty-car-booking/src/main/resources/META-INF/microprofile-config.properties
@@ -8,7 +8,7 @@ dev.langchain4j.plugin.chat-model.config.temperature=0.1
 dev.langchain4j.plugin.chat-model.config.model-name=llama3.1:latest
 dev.langchain4j.plugin.chat-model.config.log-requests=true
 dev.langchain4j.plugin.chat-model.config.log-responses=true
-dev.langchain4j.plugin.chat-model.config.listener=factory:Listener1
+dev.langchain4j.plugin.chat-model.config.listeners=lookup:@all
 
 
 dev.langchain4j.plugin.docRagRetriever.class=dev.langchain4j.rag.content.retriever.EmbeddingStoreContentRetriever

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/core/config/spi/LLMConfig.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/core/config/spi/LLMConfig.java
@@ -6,7 +6,6 @@ import jakarta.enterprise.inject.literal.NamedLiteral;
 import jakarta.enterprise.inject.spi.Bean;
 import jakarta.enterprise.inject.spi.BeanManager;
 import jakarta.enterprise.inject.spi.CDI;
-
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
@@ -28,14 +27,10 @@ import java.util.stream.Stream;
 public abstract class LLMConfig {
     Map<String, ProducerFunction<?>> producers = new ConcurrentHashMap<>();
 
-    /**
-     * Prefix for all LLM beans properties.
-     */
+    /** Prefix for all LLM beans properties. */
     public static final String PREFIX = "dev.langchain4j.plugin";
 
-    /**
-     * Called by @see LLMConfigProvider.
-     */
+    /** Called by @see LLMConfigProvider. */
     public static final String PRODUCER = "defined_bean_producer";
 
     public static final String CLASS = "class";
@@ -163,9 +158,7 @@ public abstract class LLMConfig {
     private static java.util.function.Supplier<BeanManager> beanManagerSupplier =
             () -> CDI.current().getBeanManager();
 
-    /**
-     * For tests only: override how BeanManager is obtained.
-     */
+    /** For tests only: override how BeanManager is obtained. */
     public static void setBeanManagerSupplier(java.util.function.Supplier<BeanManager> supplier) {
         beanManagerSupplier = (supplier == null) ? () -> CDI.current().getBeanManager() : supplier;
     }

--- a/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/core/config/spi/LLMConfig.java
+++ b/langchain4j-cdi-core/src/main/java/dev/langchain4j/cdi/core/config/spi/LLMConfig.java
@@ -128,7 +128,10 @@ public abstract class LLMConfig {
                     if (type instanceof ParameterizedType) return selectByBeanManager((ParameterizedType) type);
                     else return lookup.select((Class) type).get();
                 case "@all":
-                    return lookup.select((Class<?>) type).stream().toList();
+                    if (type instanceof ParameterizedType pt)
+                        return lookup.select((Class<?>) pt.getActualTypeArguments()[0]).stream()
+                                .toList();
+                    else return lookup.select((Class<?>) type).stream().toList();
                 default:
                     return getInstance(lookup, (Class<?>) type, lookupableBean).get();
             }

--- a/langchain4j-cdi-core/src/test/java/dev/langchain4j/cdi/plugin/CommonLLMPluginCreatorTest.java
+++ b/langchain4j-cdi-core/src/test/java/dev/langchain4j/cdi/plugin/CommonLLMPluginCreatorTest.java
@@ -1,5 +1,12 @@
 package dev.langchain4j.cdi.plugin;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import dev.langchain4j.cdi.core.config.TextBlockLLMConfig;
 import dev.langchain4j.cdi.core.config.spi.LLMConfigProvider;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -9,19 +16,11 @@ import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.inject.literal.NamedLiteral;
 import jakarta.enterprise.inject.spi.Bean;
 import jakarta.enterprise.inject.spi.BeanManager;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 class CommonLLMPluginCreatorTest {
 
@@ -30,8 +29,10 @@ class CommonLLMPluginCreatorTest {
 
     @SuppressWarnings("unchecked")
     public static final Instance<DummyInjected> DUMMY_INJECTED_INSTANCE_MOCKED = mock(Instance.class);
+
     public static final Instance<DummyAll.ToInjectAll> DUMMYALL_TOINJECTALL_INSTANCE_MOCKED = mock(Instance.class);
-    public static final Instance<DummyAll.ToInjectAllParameterized> DUMMYALL_TOINJECTALLPARAM_INSTANCE_MOCKED = mock(Instance.class);
+    public static final Instance<DummyAll.ToInjectAllParameterized> DUMMYALL_TOINJECTALLPARAM_INSTANCE_MOCKED =
+            mock(Instance.class);
 
     private static final TextBlockLLMConfig llmConfig = (TextBlockLLMConfig) LLMConfigProvider.getLlmConfig();
     public static final List<String> BEAN_NAMES_LIST = List.of("beanA", "beanB", "beanC");
@@ -57,9 +58,9 @@ class CommonLLMPluginCreatorTest {
         when(bm.resolve(org.mockito.ArgumentMatchers.anySet())).thenReturn((Bean) dummyParamBean);
         when(bm.createCreationalContext(dummyParamBean)).thenReturn(ctx);
         when(bm.getReference(
-                org.mockito.ArgumentMatchers.eq(dummyParamBean),
-                org.mockito.ArgumentMatchers.any(java.lang.reflect.Type.class),
-                org.mockito.ArgumentMatchers.eq(ctx)))
+                        org.mockito.ArgumentMatchers.eq(dummyParamBean),
+                        org.mockito.ArgumentMatchers.any(java.lang.reflect.Type.class),
+                        org.mockito.ArgumentMatchers.eq(ctx)))
                 .thenReturn(new DummyIntegerParam());
         dev.langchain4j.cdi.core.config.spi.LLMConfig.setBeanManagerSupplier(() -> bm);
         //
@@ -75,7 +76,7 @@ class CommonLLMPluginCreatorTest {
                         dev.langchain4j.plugin.beanA.config.dummyInjected=lookup:@default
                         dev.langchain4j.plugin.beanA.config.dummy-param-int=lookup:@default
                         dev.langchain4j.plugin.beanA.config.dummyWithStringConstructor=ok
-                        
+
                         # No scope defined to get ApplicationScoped by default
                         dev.langchain4j.plugin.beanB.class=dev.langchain4j.cdi.plugin.DummyModel
                         dev.langchain4j.plugin.beanB.config.api-key=01
@@ -86,13 +87,12 @@ class CommonLLMPluginCreatorTest {
                         dev.langchain4j.plugin.beanB.config.dummyInjected=lookup:dev.langchain4j.cdi.plugin.DummyInjected
                         dev.langchain4j.plugin.beanB.config.dummy-param-int=lookup:@default
                         dev.langchain4j.plugin.beanB.config.dummyWithStringConstructor=ok
-                        
+
                         # No scope defined to get ApplicationScoped by default
                         dev.langchain4j.plugin.beanC.class=dev.langchain4j.cdi.plugin.DummyModel
                         dev.langchain4j.plugin.beanC.defined_bean_producer=ProducerC
-                        
-                        """);
 
+                        """);
 
         llmConfig.registerProducer(
                 "ProducerC",
@@ -136,8 +136,8 @@ class CommonLLMPluginCreatorTest {
                 beanDataList.size(),
                 "Found " + beanDataList.size() + " beans: "
                         + beanDataList.stream()
-                        .map(CommonLLMPluginCreator.BeanData::beanName)
-                        .toList());
+                                .map(CommonLLMPluginCreator.BeanData::beanName)
+                                .toList());
         assertTrue(beanDataList.stream()
                 .map(CommonLLMPluginCreator.BeanData::beanName)
                 .toList()
@@ -170,8 +170,8 @@ class CommonLLMPluginCreatorTest {
                 list.isEmpty(),
                 "No BeanData should be created when builder class is missing: "
                         + list.stream()
-                        .map(CommonLLMPluginCreator.BeanData::beanName)
-                        .toList());
+                                .map(CommonLLMPluginCreator.BeanData::beanName)
+                                .toList());
     }
 
     @SuppressWarnings("SuspiciousMethodCalls")
@@ -179,7 +179,8 @@ class CommonLLMPluginCreatorTest {
     void useAllLookup() throws ClassNotFoundException {
         ;
         when(LOOKUP_MOCKED.select(DummyAll.ToInjectAll.class)).thenReturn(DUMMYALL_TOINJECTALL_INSTANCE_MOCKED);
-        when(LOOKUP_MOCKED.select(DummyAll.ToInjectAll.class, NamedLiteral.of(DummyAll.ToInjectAll.class.getName()))).thenReturn(DUMMYALL_TOINJECTALL_INSTANCE_MOCKED);
+        when(LOOKUP_MOCKED.select(DummyAll.ToInjectAll.class, NamedLiteral.of(DummyAll.ToInjectAll.class.getName())))
+                .thenReturn(DUMMYALL_TOINJECTALL_INSTANCE_MOCKED);
         List<DummyAll.ToInjectAll> toInjectAllList = new ArrayList<>();
         toInjectAllList.add(new DummyAll.ToInjectAllBeanA());
         toInjectAllList.add(new DummyAll.ToInjectAllBeanB());
@@ -191,22 +192,22 @@ class CommonLLMPluginCreatorTest {
         Bean<Object> beanB = (Bean<Object>) mock(Bean.class);
         CreationalContext<Object> ctxA = mock(CreationalContext.class);
         CreationalContext<Object> ctxB = mock(CreationalContext.class);
-        java.util.Set<Bean<?>> set = java.util.Set.of(beanA,beanB);
-        when(bm.getBeans(org.mockito.ArgumentMatchers.any(java.lang.reflect.Type.class))).thenReturn(set);
+        java.util.Set<Bean<?>> set = java.util.Set.of(beanA, beanB);
+        when(bm.getBeans(org.mockito.ArgumentMatchers.any(java.lang.reflect.Type.class)))
+                .thenReturn(set);
         when(bm.createCreationalContext(beanA)).thenReturn(ctxA);
         when(bm.createCreationalContext(beanB)).thenReturn(ctxB);
         when(bm.getReference(
-                org.mockito.ArgumentMatchers.eq(beanA),
-                org.mockito.ArgumentMatchers.any(java.lang.reflect.Type.class),
-                org.mockito.ArgumentMatchers.eq(ctxA)))
+                        org.mockito.ArgumentMatchers.eq(beanA),
+                        org.mockito.ArgumentMatchers.any(java.lang.reflect.Type.class),
+                        org.mockito.ArgumentMatchers.eq(ctxA)))
                 .thenReturn(new DummyAll.ToInjectAllParameterizedBeanA());
         when(bm.getReference(
-                org.mockito.ArgumentMatchers.eq(beanB),
-                org.mockito.ArgumentMatchers.any(java.lang.reflect.Type.class),
-                org.mockito.ArgumentMatchers.eq(ctxB)))
+                        org.mockito.ArgumentMatchers.eq(beanB),
+                        org.mockito.ArgumentMatchers.any(java.lang.reflect.Type.class),
+                        org.mockito.ArgumentMatchers.eq(ctxB)))
                 .thenReturn(new DummyAll.ToInjectAllParameterizedBeanB());
         dev.langchain4j.cdi.core.config.spi.LLMConfig.setBeanManagerSupplier(() -> bm);
-
 
         llmConfig.reinitForTest(
                 """
@@ -218,34 +219,20 @@ class CommonLLMPluginCreatorTest {
         List<CommonLLMPluginCreator.BeanData> beanDataList = new ArrayList<>();
         CommonLLMPluginCreator.prepareAllLLMBeans(llmConfig, beanDataList::add);
 
-
         assertEquals(1, beanDataList.size());
         CommonLLMPluginCreator.BeanData beanData = beanDataList.get(0);
 
         DummyAll object = (DummyAll) beanData.callback().apply(LOOKUP_MOCKED);
 
-        assertTrue(
-                object.toInjectAll.stream()
-                        .map(Object::getClass)
-                        .toList()
-                        .containsAll(
-                                List.of(
-                                        DummyAll.ToInjectAllBeanA.class,
-                                        DummyAll.ToInjectAllBeanB.class
-                                )
-                        )
-        );
-        assertTrue(
-                object.toInjectAllParameterized.stream()
-                        .map(Object::getClass)
-                        .toList()
-                        .containsAll(
-                                List.of(
-                                        DummyAll.ToInjectAllParameterizedBeanA.class,
-                                        DummyAll.ToInjectAllParameterizedBeanB.class
-                                )
-                        )
-        );
+        assertTrue(object.toInjectAll.stream()
+                .map(Object::getClass)
+                .toList()
+                .containsAll(List.of(DummyAll.ToInjectAllBeanA.class, DummyAll.ToInjectAllBeanB.class)));
+        assertTrue(object.toInjectAllParameterized.stream()
+                .map(Object::getClass)
+                .toList()
+                .containsAll(List.of(
+                        DummyAll.ToInjectAllParameterizedBeanA.class, DummyAll.ToInjectAllParameterizedBeanB.class)));
     }
 
     @Test
@@ -269,7 +256,7 @@ class CommonLLMPluginCreatorTest {
         // Null case via reflection
         var method = CommonLLMPluginCreator.class.getDeclaredMethod("getFieldsInAllHierarchy", Class.class);
         method.setAccessible(true);
-        List<?> empty = (List<?>) method.invoke(null, new Object[]{null});
+        List<?> empty = (List<?>) method.invoke(null, new Object[] {null});
         assertNotNull(empty);
         assertTrue(empty.isEmpty());
         // Parent+child aggregation

--- a/langchain4j-cdi-core/src/test/java/dev/langchain4j/cdi/plugin/CommonLLMPluginCreatorTest.java
+++ b/langchain4j-cdi-core/src/test/java/dev/langchain4j/cdi/plugin/CommonLLMPluginCreatorTest.java
@@ -1,25 +1,27 @@
 package dev.langchain4j.cdi.plugin;
 
+import dev.langchain4j.cdi.core.config.TextBlockLLMConfig;
+import dev.langchain4j.cdi.core.config.spi.LLMConfigProvider;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.enterprise.context.spi.CreationalContext;
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.inject.literal.NamedLiteral;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.BeanManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-
-import dev.langchain4j.cdi.core.config.TextBlockLLMConfig;
-import dev.langchain4j.cdi.core.config.spi.LLMConfigProvider;
-import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.enterprise.context.RequestScoped;
-import jakarta.enterprise.inject.Instance;
-import jakarta.enterprise.inject.literal.NamedLiteral;
-import jakarta.enterprise.inject.spi.Bean;
-import jakarta.enterprise.inject.spi.BeanManager;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicReference;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 
 class CommonLLMPluginCreatorTest {
 
@@ -28,10 +30,13 @@ class CommonLLMPluginCreatorTest {
 
     @SuppressWarnings("unchecked")
     public static final Instance<DummyInjected> DUMMY_INJECTED_INSTANCE_MOCKED = mock(Instance.class);
+    public static final Instance<DummyAll.ToInjectAll> DUMMYALL_TOINJECTALL_INSTANCE_MOCKED = mock(Instance.class);
+    public static final Instance<DummyAll.ToInjectAllParameterized> DUMMYALL_TOINJECTALLPARAM_INSTANCE_MOCKED = mock(Instance.class);
 
     private static final TextBlockLLMConfig llmConfig = (TextBlockLLMConfig) LLMConfigProvider.getLlmConfig();
     public static final List<String> BEAN_NAMES_LIST = List.of("beanA", "beanB", "beanC");
 
+    @SuppressWarnings({"unchecked", "rawtypes"})
     @BeforeEach
     void beforeEach() {
         DummyInjected dummyInjectedMocked = mock(DummyInjected.class);
@@ -45,17 +50,16 @@ class CommonLLMPluginCreatorTest {
         BeanManager bm = mock(BeanManager.class);
         @SuppressWarnings("unchecked")
         Bean<Object> dummyParamBean = (Bean<Object>) mock(Bean.class);
-        jakarta.enterprise.context.spi.CreationalContext<Object> ctx =
-                mock(jakarta.enterprise.context.spi.CreationalContext.class);
+        CreationalContext<Object> ctx = mock(CreationalContext.class);
         java.util.Set<Bean<?>> set = java.util.Set.of(dummyParamBean);
         when(bm.getBeans(org.mockito.ArgumentMatchers.any(java.lang.reflect.Type.class)))
-                .thenReturn((java.util.Set) set);
+                .thenReturn(set);
         when(bm.resolve(org.mockito.ArgumentMatchers.anySet())).thenReturn((Bean) dummyParamBean);
         when(bm.createCreationalContext(dummyParamBean)).thenReturn(ctx);
         when(bm.getReference(
-                        org.mockito.ArgumentMatchers.eq(dummyParamBean),
-                        org.mockito.ArgumentMatchers.any(java.lang.reflect.Type.class),
-                        org.mockito.ArgumentMatchers.eq(ctx)))
+                org.mockito.ArgumentMatchers.eq(dummyParamBean),
+                org.mockito.ArgumentMatchers.any(java.lang.reflect.Type.class),
+                org.mockito.ArgumentMatchers.eq(ctx)))
                 .thenReturn(new DummyIntegerParam());
         dev.langchain4j.cdi.core.config.spi.LLMConfig.setBeanManagerSupplier(() -> bm);
         //
@@ -71,7 +75,7 @@ class CommonLLMPluginCreatorTest {
                         dev.langchain4j.plugin.beanA.config.dummyInjected=lookup:@default
                         dev.langchain4j.plugin.beanA.config.dummy-param-int=lookup:@default
                         dev.langchain4j.plugin.beanA.config.dummyWithStringConstructor=ok
-
+                        
                         # No scope defined to get ApplicationScoped by default
                         dev.langchain4j.plugin.beanB.class=dev.langchain4j.cdi.plugin.DummyModel
                         dev.langchain4j.plugin.beanB.config.api-key=01
@@ -82,12 +86,14 @@ class CommonLLMPluginCreatorTest {
                         dev.langchain4j.plugin.beanB.config.dummyInjected=lookup:dev.langchain4j.cdi.plugin.DummyInjected
                         dev.langchain4j.plugin.beanB.config.dummy-param-int=lookup:@default
                         dev.langchain4j.plugin.beanB.config.dummyWithStringConstructor=ok
-
+                        
                         # No scope defined to get ApplicationScoped by default
                         dev.langchain4j.plugin.beanC.class=dev.langchain4j.cdi.plugin.DummyModel
                         dev.langchain4j.plugin.beanC.defined_bean_producer=ProducerC
-
+                        
                         """);
+
+
         llmConfig.registerProducer(
                 "ProducerC",
                 (lookup, beanName, llmCOnfig) -> new DummyModel(
@@ -130,8 +136,8 @@ class CommonLLMPluginCreatorTest {
                 beanDataList.size(),
                 "Found " + beanDataList.size() + " beans: "
                         + beanDataList.stream()
-                                .map(CommonLLMPluginCreator.BeanData::beanName)
-                                .toList());
+                        .map(CommonLLMPluginCreator.BeanData::beanName)
+                        .toList());
         assertTrue(beanDataList.stream()
                 .map(CommonLLMPluginCreator.BeanData::beanName)
                 .toList()
@@ -164,8 +170,82 @@ class CommonLLMPluginCreatorTest {
                 list.isEmpty(),
                 "No BeanData should be created when builder class is missing: "
                         + list.stream()
-                                .map(CommonLLMPluginCreator.BeanData::beanName)
-                                .toList());
+                        .map(CommonLLMPluginCreator.BeanData::beanName)
+                        .toList());
+    }
+
+    @SuppressWarnings("SuspiciousMethodCalls")
+    @Test
+    void useAllLookup() throws ClassNotFoundException {
+        ;
+        when(LOOKUP_MOCKED.select(DummyAll.ToInjectAll.class)).thenReturn(DUMMYALL_TOINJECTALL_INSTANCE_MOCKED);
+        when(LOOKUP_MOCKED.select(DummyAll.ToInjectAll.class, NamedLiteral.of(DummyAll.ToInjectAll.class.getName()))).thenReturn(DUMMYALL_TOINJECTALL_INSTANCE_MOCKED);
+        List<DummyAll.ToInjectAll> toInjectAllList = new ArrayList<>();
+        toInjectAllList.add(new DummyAll.ToInjectAllBeanA());
+        toInjectAllList.add(new DummyAll.ToInjectAllBeanB());
+        when(DUMMYALL_TOINJECTALL_INSTANCE_MOCKED.stream()).thenReturn(toInjectAllList.stream());
+
+        BeanManager bm = mock(BeanManager.class);
+        @SuppressWarnings("unchecked")
+        Bean<Object> beanA = (Bean<Object>) mock(Bean.class);
+        Bean<Object> beanB = (Bean<Object>) mock(Bean.class);
+        CreationalContext<Object> ctxA = mock(CreationalContext.class);
+        CreationalContext<Object> ctxB = mock(CreationalContext.class);
+        java.util.Set<Bean<?>> set = java.util.Set.of(beanA,beanB);
+        when(bm.getBeans(org.mockito.ArgumentMatchers.any(java.lang.reflect.Type.class))).thenReturn(set);
+        when(bm.createCreationalContext(beanA)).thenReturn(ctxA);
+        when(bm.createCreationalContext(beanB)).thenReturn(ctxB);
+        when(bm.getReference(
+                org.mockito.ArgumentMatchers.eq(beanA),
+                org.mockito.ArgumentMatchers.any(java.lang.reflect.Type.class),
+                org.mockito.ArgumentMatchers.eq(ctxA)))
+                .thenReturn(new DummyAll.ToInjectAllParameterizedBeanA());
+        when(bm.getReference(
+                org.mockito.ArgumentMatchers.eq(beanB),
+                org.mockito.ArgumentMatchers.any(java.lang.reflect.Type.class),
+                org.mockito.ArgumentMatchers.eq(ctxB)))
+                .thenReturn(new DummyAll.ToInjectAllParameterizedBeanB());
+        dev.langchain4j.cdi.core.config.spi.LLMConfig.setBeanManagerSupplier(() -> bm);
+
+
+        llmConfig.reinitForTest(
+                """
+                        dev.langchain4j.plugin.beanAll.class=dev.langchain4j.cdi.plugin.DummyAll
+                        dev.langchain4j.plugin.beanAll.config.toInjectAll=lookup:@all
+                        dev.langchain4j.plugin.beanAll.config.toInjectAllParameterized=lookup:@all
+                        """);
+
+        List<CommonLLMPluginCreator.BeanData> beanDataList = new ArrayList<>();
+        CommonLLMPluginCreator.prepareAllLLMBeans(llmConfig, beanDataList::add);
+
+
+        assertEquals(1, beanDataList.size());
+        CommonLLMPluginCreator.BeanData beanData = beanDataList.get(0);
+
+        DummyAll object = (DummyAll) beanData.callback().apply(LOOKUP_MOCKED);
+
+        assertTrue(
+                object.toInjectAll.stream()
+                        .map(Object::getClass)
+                        .toList()
+                        .containsAll(
+                                List.of(
+                                        DummyAll.ToInjectAllBeanA.class,
+                                        DummyAll.ToInjectAllBeanB.class
+                                )
+                        )
+        );
+        assertTrue(
+                object.toInjectAllParameterized.stream()
+                        .map(Object::getClass)
+                        .toList()
+                        .containsAll(
+                                List.of(
+                                        DummyAll.ToInjectAllParameterizedBeanA.class,
+                                        DummyAll.ToInjectAllParameterizedBeanB.class
+                                )
+                        )
+        );
     }
 
     @Test
@@ -189,7 +269,7 @@ class CommonLLMPluginCreatorTest {
         // Null case via reflection
         var method = CommonLLMPluginCreator.class.getDeclaredMethod("getFieldsInAllHierarchy", Class.class);
         method.setAccessible(true);
-        List<?> empty = (List<?>) method.invoke(null, new Object[] {null});
+        List<?> empty = (List<?>) method.invoke(null, new Object[]{null});
         assertNotNull(empty);
         assertTrue(empty.isEmpty());
         // Parent+child aggregation

--- a/langchain4j-cdi-core/src/test/java/dev/langchain4j/cdi/plugin/DummyAll.java
+++ b/langchain4j-cdi-core/src/test/java/dev/langchain4j/cdi/plugin/DummyAll.java
@@ -33,32 +33,19 @@ public class DummyAll {
         }
 
         public DummyAll build() {
-            return new DummyAll(
-                    toInjectAll,
-                    toInjectAllParameterized
-            );
+            return new DummyAll(toInjectAll, toInjectAllParameterized);
         }
     }
 
+    interface ToInjectAll {}
 
-    interface ToInjectAll {
+    interface ToInjectAllParameterized<T> {}
 
-    }
+    public static class ToInjectAllBeanA implements ToInjectAll {}
 
-    interface ToInjectAllParameterized<T> {
-    }
+    public static class ToInjectAllBeanB implements ToInjectAll {}
 
+    public static class ToInjectAllParameterizedBeanA implements ToInjectAllParameterized<String> {}
 
-    public static class ToInjectAllBeanA implements ToInjectAll {
-    }
-
-    public static class ToInjectAllBeanB implements ToInjectAll {
-    }
-
-    public static class ToInjectAllParameterizedBeanA implements ToInjectAllParameterized<String> {
-    }
-
-    public static class ToInjectAllParameterizedBeanB implements ToInjectAllParameterized<String> {
-    }
-
+    public static class ToInjectAllParameterizedBeanB implements ToInjectAllParameterized<String> {}
 }

--- a/langchain4j-cdi-core/src/test/java/dev/langchain4j/cdi/plugin/DummyAll.java
+++ b/langchain4j-cdi-core/src/test/java/dev/langchain4j/cdi/plugin/DummyAll.java
@@ -1,0 +1,64 @@
+package dev.langchain4j.cdi.plugin;
+
+import java.util.List;
+import java.util.Set;
+
+public class DummyAll {
+
+    final List<ToInjectAll> toInjectAll;
+    final Set<ToInjectAllParameterized<String>> toInjectAllParameterized;
+
+    public DummyAll(List<ToInjectAll> toInjectAll, Set<ToInjectAllParameterized<String>> toInjectAllParameterized) {
+        this.toInjectAll = toInjectAll;
+        this.toInjectAllParameterized = toInjectAllParameterized;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    protected static class Builder {
+        // fields that mirror expected property names (after dashToCamel conversion)
+        public List<ToInjectAll> toInjectAll;
+        public Set<ToInjectAllParameterized<String>> toInjectAllParameterized;
+
+        public Builder toInjectAll(List<ToInjectAll> v) {
+            this.toInjectAll = v;
+            return this;
+        }
+
+        public Builder toInjectAllParameterized(Set<ToInjectAllParameterized<String>> v) {
+            this.toInjectAllParameterized = v;
+            return this;
+        }
+
+        public DummyAll build() {
+            return new DummyAll(
+                    toInjectAll,
+                    toInjectAllParameterized
+            );
+        }
+    }
+
+
+    interface ToInjectAll {
+
+    }
+
+    interface ToInjectAllParameterized<T> {
+    }
+
+
+    public static class ToInjectAllBeanA implements ToInjectAll {
+    }
+
+    public static class ToInjectAllBeanB implements ToInjectAll {
+    }
+
+    public static class ToInjectAllParameterizedBeanA implements ToInjectAllParameterized<String> {
+    }
+
+    public static class ToInjectAllParameterizedBeanB implements ToInjectAllParameterized<String> {
+    }
+
+}


### PR DESCRIPTION
Fix bug where LLMConfig did a CDI lookup for all `ChatModelListener` by `ParameterizedType`'s actual implementation instead of its actual `ParameterizedType`'s type argument. Field is `List<ChatModelListener> listeners`;