### PR TITLE
Fixed issues that prevented creation of objects through MP config and configured all examples to support RAG (was missing).

### DIFF
--- a/examples/glassfish-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/ChatAiService.java
+++ b/examples/glassfish-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/ChatAiService.java
@@ -6,6 +6,7 @@ import dev.langchain4j.service.SystemMessage;
 @SuppressWarnings("CdiManagedBeanInconsistencyInspection")
 @RegisterAIService(
         tools = BookingService.class,
+        contentRetrieverName = "docRagRetriever",
         chatMemoryName = "chat-ai-service-memory",
         chatModelName = "chat-model")
 public interface ChatAiService {

--- a/examples/glassfish-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/FraudAiService.java
+++ b/examples/glassfish-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/FraudAiService.java
@@ -6,7 +6,10 @@ import dev.langchain4j.service.UserMessage;
 import dev.langchain4j.service.V;
 
 @SuppressWarnings("CdiManagedBeanInconsistencyInspection")
-@RegisterAIService(chatMemoryName = "fraud-ai-service-memory", chatModelName = "chat-model")
+@RegisterAIService(
+        contentRetrieverName = "docRagRetriever",
+        chatMemoryName = "fraud-ai-service-memory",
+        chatModelName = "chat-model")
 public interface FraudAiService {
 
     @SystemMessage(

--- a/examples/helidon-car-booking-portable-ext/src/main/java/dev/langchain4j/cdi/example/booking/ChatAiService.java
+++ b/examples/helidon-car-booking-portable-ext/src/main/java/dev/langchain4j/cdi/example/booking/ChatAiService.java
@@ -10,6 +10,7 @@ import org.eclipse.microprofile.faulttolerance.Timeout;
 @SuppressWarnings("CdiManagedBeanInconsistencyInspection")
 @RegisterAIService(
         tools = BookingService.class,
+        contentRetrieverName = "docRagRetriever",
         chatMemoryName = "chat-ai-service-memory",
         chatModelName = "chat-model")
 public interface ChatAiService {

--- a/examples/helidon-car-booking-portable-ext/src/main/java/dev/langchain4j/cdi/example/booking/FraudAiService.java
+++ b/examples/helidon-car-booking-portable-ext/src/main/java/dev/langchain4j/cdi/example/booking/FraudAiService.java
@@ -10,7 +10,10 @@ import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.faulttolerance.Timeout;
 
 @SuppressWarnings("CdiManagedBeanInconsistencyInspection")
-@RegisterAIService(chatMemoryName = "fraud-ai-service-memory", chatModelName = "chat-model")
+@RegisterAIService(
+        contentRetrieverName = "docRagRetriever",
+        chatMemoryName = "fraud-ai-service-memory",
+        chatModelName = "chat-model")
 public interface FraudAiService {
 
     @SystemMessage(

--- a/examples/helidon-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/ChatAiService.java
+++ b/examples/helidon-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/ChatAiService.java
@@ -10,6 +10,7 @@ import org.eclipse.microprofile.faulttolerance.Timeout;
 @SuppressWarnings("CdiManagedBeanInconsistencyInspection")
 @RegisterAIService(
         tools = BookingService.class,
+        contentRetrieverName = "docRagRetriever",
         chatMemoryName = "chat-ai-service-memory",
         chatModelName = "chat-model")
 public interface ChatAiService {

--- a/examples/helidon-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/FraudAiService.java
+++ b/examples/helidon-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/FraudAiService.java
@@ -10,7 +10,10 @@ import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.faulttolerance.Timeout;
 
 @SuppressWarnings("CdiManagedBeanInconsistencyInspection")
-@RegisterAIService(chatMemoryName = "fraud-ai-service-memory", chatModelName = "chat-model")
+@RegisterAIService(
+        contentRetrieverName = "docRagRetriever",
+        chatMemoryName = "fraud-ai-service-memory",
+        chatModelName = "chat-model")
 public interface FraudAiService {
 
     @SystemMessage(

--- a/examples/liberty-car-booking/pom.xml
+++ b/examples/liberty-car-booking/pom.xml
@@ -24,8 +24,8 @@
         <compiler-plugin.version>3.13.0</compiler-plugin.version>
         <war-plugin.version>3.4.0</war-plugin.version>
         <!-- We need only javac to use the release parameter. OpenLiberty doesn't depend on maven-compiler-plugin.' -->
-        <maven.compiler.source combine.self="override" />
-        <maven.compiler.target combine.self="override" />
+        <maven.compiler.source combine.self="override"></maven.compiler.source>
+        <maven.compiler.target combine.self="override"></maven.compiler.target>
 
         <version.io.smallrye.fault-tolerance>6.7.3</version.io.smallrye.fault-tolerance>
         <!--Strictly for OpenLiberty-->

--- a/examples/liberty-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/ChatAiService.java
+++ b/examples/liberty-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/ChatAiService.java
@@ -10,6 +10,8 @@ import org.eclipse.microprofile.faulttolerance.Timeout;
 
 // @SuppressWarnings("CdiManagedBeanInconsistencyInspection")
 @RegisterAIService(
+        chatModelName = "chat-model",
+        contentRetrieverName = "docRagRetriever",
         scope = ApplicationScoped.class,
         tools = BookingService.class,
         chatMemoryName = "chat-ai-service-memory")

--- a/examples/liberty-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/FraudAiService.java
+++ b/examples/liberty-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/FraudAiService.java
@@ -9,7 +9,10 @@ import org.eclipse.microprofile.faulttolerance.Fallback;
 import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.faulttolerance.Timeout;
 
-@RegisterAIService(chatMemoryName = "fraud-ai-service-memory", chatModelName = "chat-model")
+@RegisterAIService(
+        contentRetrieverName = "docRagRetriever",
+        chatMemoryName = "fraud-ai-service-memory",
+        chatModelName = "chat-model")
 public interface FraudAiService {
 
     @SystemMessage(

--- a/examples/payara-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/ChatAiService.java
+++ b/examples/payara-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/ChatAiService.java
@@ -6,6 +6,7 @@ import dev.langchain4j.service.SystemMessage;
 @SuppressWarnings("CdiManagedBeanInconsistencyInspection")
 @RegisterAIService(
         tools = BookingService.class,
+        contentRetrieverName = "docRagRetriever",
         chatMemoryName = "chat-ai-service-memory",
         chatModelName = "chat-model")
 public interface ChatAiService {

--- a/examples/payara-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/FraudAiService.java
+++ b/examples/payara-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/FraudAiService.java
@@ -6,7 +6,10 @@ import dev.langchain4j.service.UserMessage;
 import dev.langchain4j.service.V;
 
 @SuppressWarnings("CdiManagedBeanInconsistencyInspection")
-@RegisterAIService(chatMemoryName = "fraud-ai-service-memory", chatModelName = "chat-model")
+@RegisterAIService(
+        contentRetrieverName = "docRagRetriever",
+        chatMemoryName = "fraud-ai-service-memory",
+        chatModelName = "chat-model")
 public interface FraudAiService {
 
     @SystemMessage(

--- a/examples/quarkus-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/ChatAiService.java
+++ b/examples/quarkus-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/ChatAiService.java
@@ -8,7 +8,10 @@ import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.faulttolerance.Timeout;
 
 @SuppressWarnings("CdiManagedBeanInconsistencyInspection")
-@RegisterAIService(tools = BookingService.class, chatMemoryName = "chat-ai-service-memory")
+@RegisterAIService(
+        tools = BookingService.class,
+        contentRetrieverName = "docRagRetriever",
+        chatMemoryName = "chat-ai-service-memory")
 public interface ChatAiService {
 
     @SystemMessage(

--- a/examples/quarkus-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/FraudAiService.java
+++ b/examples/quarkus-car-booking/src/main/java/dev/langchain4j/cdi/example/booking/FraudAiService.java
@@ -10,7 +10,7 @@ import org.eclipse.microprofile.faulttolerance.Retry;
 import org.eclipse.microprofile.faulttolerance.Timeout;
 
 @SuppressWarnings("CdiManagedBeanInconsistencyInspection")
-@RegisterAIService(chatMemoryName = "fraud-ai-service-memory")
+@RegisterAIService(contentRetrieverName = "docRagRetriever", chatMemoryName = "fraud-ai-service-memory")
 public interface FraudAiService {
 
     @SystemMessage(

--- a/langchain4j-cdi-core/src/test/java/dev/langchain4j/cdi/plugin/CommonLLMPluginCreatorTest.java
+++ b/langchain4j-cdi-core/src/test/java/dev/langchain4j/cdi/plugin/CommonLLMPluginCreatorTest.java
@@ -236,7 +236,7 @@ class CommonLLMPluginCreatorTest {
     }
 
     @Test
-    void create_missingField_throwsRuntimeWrappingNoSuchField() throws ClassNotFoundException {
+    void create_missingField_throwsRuntimeWrappingReflectiveOperation() throws ClassNotFoundException {
         llmConfig.reinitForTest(
                 """
                         dev.langchain4j.plugin.bad.class=dev.langchain4j.cdi.plugin.DummyModel
@@ -247,7 +247,7 @@ class CommonLLMPluginCreatorTest {
         RuntimeException ex = assertThrows(
                 RuntimeException.class,
                 () -> CommonLLMPluginCreator.create(LOOKUP_MOCKED, llmConfig, "bad", target, builder));
-        assertTrue(ex.getCause() instanceof NoSuchFieldException);
+        assertTrue(ex.getCause() instanceof ReflectiveOperationException);
         assertTrue(ex.getMessage().contains("unknown-prop"));
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -64,8 +64,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <dev.langchain4j.version>1.6.0</dev.langchain4j.version>
-        <dev.langchain4j.community.version>1.6.0-beta12</dev.langchain4j.community.version>
+        <dev.langchain4j.version>1.7.1</dev.langchain4j.version>
+        <dev.langchain4j.community.version>1.7.1-beta14</dev.langchain4j.community.version>
         <jakartaee-api.version>10.0.0</jakartaee-api.version>
         <jakarta.enterprise.cdi-api.version>4.0.1</jakarta.enterprise.cdi-api.version>
 


### PR DESCRIPTION
See issue #101.

1. Updated LangChain4J to version 1.7.1 and community to 1.7.1-beta14
2. Fixed all examples to include RAG (were missing `contentRetrieverName` on `RegisterAiService` annotation).
3. Fixed issue where enums were not converted to its correct value.
4. Fixed issue where values expected a `Set` exception was thrown (due to `ParameterizedType` mismatch).
5. Fixed the issue of mapping MP config property value to its corresponding LangChain4J Builder object where the field doesn't exist but the builder method exists (of the same name).
